### PR TITLE
Fix query selection execution background color

### DIFF
--- a/client/app/components/QueryEditor.css
+++ b/client/app/components/QueryEditor.css
@@ -1,8 +1,3 @@
-@keyframes fadeIt {
-    0%   { background-color: rgba(255, 121, 100, 0.557); }
-    100% { background-color: transparent; }
-}
-
-.ace_editor.highlightedText .ace_marker-layer .ace_selection {
-    animation: fadeIt 0.5s ease-out;
+.editor__container[data-executing="true"] .ace_marker-layer .ace_selection {
+    background-color: rgb(255, 210, 181);
 }

--- a/client/app/components/QueryEditor.jsx
+++ b/client/app/components/QueryEditor.jsx
@@ -223,9 +223,8 @@ class QueryEditor extends React.Component {
     return (
       <section style={{ height: '100%' }} data-test="QueryEditor">
         <div className="container p-15 m-b-10" style={{ height: '100%' }}>
-          <div style={{ height: 'calc(100% - 40px)', marginBottom: '0px' }} className="editor__container">
+          <div data-executing={this.props.queryExecuting} style={{ height: 'calc(100% - 40px)', marginBottom: '0px' }} className="editor__container">
             <AceEditor
-              className={(this.props.queryExecuting) ? 'highlightedText' : ''}
               ref={this.refEditor}
               theme="textmate"
               mode={this.props.dataSource.syntax || 'sql'}


### PR DESCRIPTION
@chang I think you're doing a great job with the feature!
Your implementation of the highlight color is a bit problematic since it overrides the original Ace classnames, so here's a safer approach using an 'attribute selector'.